### PR TITLE
Do not allow login if user.is_active=False

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## 2.1.15
+### Fixed
+- Check if user.is\_active==True before allowing user to connect
+
 ## 2.1.14
 ### Fixed
 - Accidently removing other parameters in url than the ask one, like 'key'

--- a/django_tequila/middleware.py
+++ b/django_tequila/middleware.py
@@ -24,18 +24,18 @@ def get_query_string(params, new_params=None, remove=None):
         for k in p.keys():
             if k.startswith(r):
                 del p[k]
-                
+
     for k, v in new_params.items():
         if v is None:
             if k in p:
                 del p[k]
         else:
             p[k] = v
-    
+
     for k, v in p.items():
         if isinstance(v, (list,tuple)):
             p[k] = v[0]
-    
+
     return '?%s' % urlencode(p)
 
 class TequilaMiddleware(PersistentRemoteUserMiddleware):
@@ -50,11 +50,11 @@ class TequilaMiddleware(PersistentRemoteUserMiddleware):
 
     # Name of request key to grab the key from
     header = "key"
-    
+
     def process_request(self, request):
         # AuthenticationMiddleware is required so that request.user exists.
         if not hasattr(request, 'user'):
-            return 
+            return
             raise ImproperlyConfigured(
                 "The Django remote user auth middleware requires the"
                 " authentication middleware to be installed.  Edit your"
@@ -76,7 +76,7 @@ class TequilaMiddleware(PersistentRemoteUserMiddleware):
             if self.force_logout_if_no_header and request.user.is_authenticated:
                 self._remove_invalid_user(request)
             return
-        
+
         # We are seeing this user for the first time in this session, attempt
         # to authenticate the user.
         logger.debug("First time user found, going for authentication "
@@ -97,6 +97,10 @@ class TequilaMiddleware(PersistentRemoteUserMiddleware):
                          "redirect to the not allowed page")
             return HttpResponseRedirect(settings.LOGIN_REDIRECT_IF_NOT_ALLOWED)
         else:
+            if not user.is_active:
+                # Do not allow login if user is inactive
+                # Use flag TEQUILA_NEW_USER_INACTIVE in settings to define default value for is_active
+                return HttpResponseRedirect(settings.LOGIN_REDIRECT_IF_NOT_ALLOWED)
             # User is valid.  Set request.user and persist user in the session
             # by logging the user in.
             request.user = user
@@ -105,16 +109,16 @@ class TequilaMiddleware(PersistentRemoteUserMiddleware):
 
             try:
                 clean_url = settings.TEQUILA_CLEAN_URL
-                
+
                 if clean_url:
                     #get the url, remove key and redirect to it
                     cleaned_url = request.path
-                    
+
                     #QueryDict to dict
                     params = dict(request.GET.iterlists())
-                    
+
                     cleaned_url += get_query_string(params, remove=[self.header])
                     return HttpResponseRedirect(cleaned_url)
 
             except AttributeError:
-                pass    
+                pass


### PR DESCRIPTION
The checking of the user.is_active flag was removed in this [commit](https://github.com/epfl-idevelop/django-tequila/commit/a02acf8058f152daf597987e34472e11265e7796)

I guess it is a mistake, as currently it is not checked at all, so any user with a valid Tequila Account can connect anywhere without the need to have the flag `is_active` at True.

As it is possible to set the default value for the `is_active` field in a per-app way, the check should be done all the time.