### PR TITLE
Fix a strange __unicode__() call

### DIFF
--- a/django_tequila/middleware.py
+++ b/django_tequila/middleware.py
@@ -86,7 +86,7 @@ class TequilaMiddleware(PersistentRemoteUserMiddleware):
         logger.debug("User found and logged : %s" % user.__dict__)
 
         if hasattr(user, 'profile'):
-            logger.debug("User profile : %s" % user.profile)
+            logger.debug("User profile : %s" % user.profile.__dict__)
         else:
             logger.debug("The current appplication has no profile model "
                          "set, returned informations will not be saved")

--- a/django_tequila/middleware.py
+++ b/django_tequila/middleware.py
@@ -86,7 +86,7 @@ class TequilaMiddleware(PersistentRemoteUserMiddleware):
         logger.debug("User found and logged : %s" % user.__dict__)
 
         if hasattr(user, 'profile'):
-            logger.debug("User profile : %s" % user.profile.__unicode__())
+            logger.debug("User profile : %s" % user.profile)
         else:
             logger.debug("The current appplication has no profile model "
                          "set, returned informations will not be saved")


### PR DESCRIPTION
__unicode__() n'existe plus en python 3

L'appel à __unicode__() semble superflu.
Le modèle Django UserProfile doit avoir une méthode 
- __unicode__() en python 2
- __str__() en python 3
 
Testé en : 
- python 2.7.12 et django 1.10
- python 3.6.2 et django 1.11.5
