### PR TITLE
custom text on not_allowed page

### DIFF
--- a/django_tequila/tequila_auth_views/__init__.py
+++ b/django_tequila/tequila_auth_views/__init__.py
@@ -87,4 +87,8 @@ def logout(request):
 
 
 def not_allowed(request):
-    return HttpResponse("Not allowed")
+    try :
+        not_allow_text = settings.TEQUILA_NOT_ALLOWED_TEXT
+    except AttributeError :
+        not_allow_text = "Not allowed"
+    return HttpResponse(not_allow_text)

--- a/sample_app/settings.py
+++ b/sample_app/settings.py
@@ -115,6 +115,7 @@ LOGIN_URL = "/login"
 LOGIN_REDIRECT_URL = "/"
 LOGIN_REDIRECT_IF_NOT_ALLOWED = "/not_allowed"
 LOGOUT_URL = "/"
+TEQUILA_NOT_ALLOWED_TEXT = "Not allowed : please contact your admin"
 
 LOGGING = {
     'version': 1,


### PR DESCRIPTION
Let the developer choose a small text to display on the not_allowed page.

**How to use it** 
On settings.py : 
```python 
TEQUILA_NOT_ALLOWED_TEXT = "Not allowed : please contact your admin"
```
This will allow the developer to inform his users what to do if this page is showing. (For example contact an admin or anything like this.)
If `TEQUILA_NOT_ALLOWED_TEXT` is not in settings.py, the previous base text "Not allowed" will be displayed.